### PR TITLE
Even an unused Page.route() has an impact on behaviour

### DIFF
--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -24,15 +24,17 @@ export async function deleteServerRecordedEvents({ testId }: TestInfo) {
 export async function setupPassthroughRoute(page: Page, { testId }: TestInfo) {
   const payloads: Record<string, unknown>[] = [];
   const getPayloads = () => payloads;
-  await page.route(`${SERVER_URL}/api/${testId}/events`, async (route) => {
+  await page.route(`${SERVER_URL}/foobar`, async (route) => {
     const url = route.request().url();
     const method = route.request().method();
     if (method === "POST") {
       const payload = route.request().postDataJSON();
       console.log(`Playwright route triggered: ${method} ${url}`);
       payloads.push(payload);
+      await route.fulfill({ status: 202, contentType: 'text/plain', body: 'ok' });
+    } else {
+      await route.fulfill({status: 500, contentType: 'text/plain', body: 'Internal Server Error'});
     }
-    await route.continue();
   });
   return { getPayloads };
 }

--- a/test/track.spec.ts
+++ b/test/track.spec.ts
@@ -18,14 +18,14 @@ test("track works", async ({ page }, testInfo) => {
   );
   await page.fill('input[name="text"]', "Hello World");
   await page.click('input[type="submit"]');
+  // expect(getPayloads()).toEqual([
+  //   {
+  //     action: "submit",
+  //     page: "page-alfa",
+  //     timestamp: expect.any(String),
+  //   },
+  // ]);
   expect(await getServerRecordedEvents(testInfo)).toEqual([
-    {
-      action: "submit",
-      page: "page-alfa",
-      timestamp: expect.any(String),
-    },
-  ]);
-  expect(getPayloads()).toEqual([
     {
       action: "submit",
       page: "page-alfa",


### PR DESCRIPTION
These changes show that using Page.route() API within the test, even if the route isn't used, interferes on webkit with the server receiving the event